### PR TITLE
Add build script for android

### DIFF
--- a/client/chark/bin/build
+++ b/client/chark/bin/build
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd android 
+./gradlew assembleRelease
+
+Green='\033[1;32m'
+Yellow='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${Yellow}Path(if the build is successful):${Green} android/app/build/outputs/apk/release${NC}"

--- a/client/chark/package.json
+++ b/client/chark/package.json
@@ -8,7 +8,8 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint .",
-    "develop": "bin/develop"
+    "develop": "bin/develop",
+    "build-apk": "bin/build"
   },
   "dependencies": {
     "@craftzdog/react-native-buffer": "^6.0.5",


### PR DESCRIPTION
Added a script `build-apk` for building android apk.
cd into chark folder and then run: `npm run build-apk`

The apk will be created in the folder: `android/app/build/outputs/apk/release`