### PR TITLE
Fetch and cache partner pictures

### DIFF
--- a/client/chark/src/config/constants.js
+++ b/client/chark/src/config/constants.js
@@ -39,3 +39,7 @@ export const connectsObj = {
   "phone":"Phone",
   "cell": "Cell"
 }
+
+export const localStorage = {
+  TallyPictures: 'TallyPictures',
+};

--- a/client/chark/src/screens/Tally/TallyItem/index.jsx
+++ b/client/chark/src/screens/Tally/TallyItem/index.jsx
@@ -1,7 +1,8 @@
-import React from 'react'; import { View, Image, Text, StyleSheet } from 'react-native';
+import React , { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
-import { colors, placeholderImages } from '../../../config/constants';
+import { colors } from '../../../config/constants';
 import { round } from '../../../utils/common';
 
 import Avatar from '../../../components/Avatar';
@@ -16,7 +17,7 @@ const TallyItem = (props) => {
   return (
     <View style={styles.container}>
 
-      <Avatar style={styles.avatar} />
+      <Avatar style={styles.avatar} avatar={props.image} />
 
       <View style={{ flex: 1, }}>
         <Text style={styles.name}>{`${partCert?.name?.first}${partCert?.name?.middle ? ' ' + partCert?.name?.middle + ' ' : ''} ${partCert?.name?.surname}`}</Text>

--- a/client/chark/src/screens/Tally/index.jsx
+++ b/client/chark/src/screens/Tally/index.jsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { View, StyleSheet, FlatList, TouchableWithoutFeedback, Text } from 'react-native';
+import { View, StyleSheet, FlatList, TouchableWithoutFeedback } from 'react-native';
+import { Buffer } from 'buffer';
+import AsyncStorage from '@react-native-async-storage/async-storage'
 
 import useSocket from '../../hooks/useSocket';
 import useProfile from '../../hooks/useProfile';
 import { round } from '../../utils/common';
 import useCurrentUser from '../../hooks/useCurrentUser';;
-import { fetchTallies } from '../../services/tally';
+import { fetchTallies, fetchTallyFile } from '../../services/tally';
 import { getCurrency } from '../../services/user';
 import { useUserTalliesText } from '../../hooks/useLanguage';
+import { localStorage } from '../../config/constants';
 
 import TallyItem from './TallyItem';
 import TallyHeader from './TallyHeader';
@@ -21,6 +24,7 @@ const Tally = (props) => {
   const [loading, setLoading] = useState(false);
   const [tallies, setTallies] = useState([]);
   const [conversionRate, setConversionRate] = useState(0);
+  const [imagesByDigest, setImagesByDigest] = useState({})  // will be as {[digest]: 'base64'}
 
   const currencyCode = preferredCurrency.code;
 
@@ -68,6 +72,22 @@ const Tally = (props) => {
     }).then(data => {
       if (data) {
         setTallies(data);
+
+        const hashes = [];
+        for(let tally of data) {
+          const digest = tally?.part_cert?.file?.[0]?.digest;
+          const tally_seq = tally?.tally_seq;
+
+          if(digest) {
+            hashes.push({
+              tally_seq,
+              digest,
+            });
+          }
+        }
+
+        // Fetch images by digest
+        fetchImagesByDigest(wm, hashes, setImagesByDigest).catch(console.log)
       }
     }).catch(err => {
       console.log('Error fetching tallies', err)
@@ -95,6 +115,7 @@ const Tally = (props) => {
       <View style={[styles.item, index === tallies?.length - 1 ? styles.itemLast : null]}>
         <TallyItem
           tally={item}
+          image={imagesByDigest[item?.part_cert?.file?.[0]?.digest]}
           conversionRate={conversionRate} 
           currency={preferredCurrency?.code}
         />
@@ -122,6 +143,53 @@ const Tally = (props) => {
       onRefresh={_fetchTallies}
     />
   )
+}
+
+async function fetchImagesByDigest(wm, hashes, setImagesByDigest) {
+  const promises = [];
+
+  let imagesByDigest = {};
+  try {
+    const storageValue = await AsyncStorage.getItem(localStorage.TallyPictures);
+    imagesByDigest = JSON.parse(storageValue ?? {});
+  } catch(err) {
+    imagesByDigest = {};
+  }
+
+  for(let hash of hashes) {
+    if(hash.digest in imagesByDigest) {
+      continue;
+    }
+
+    promises.push(fetchTallyFile(wm, hash.digest, hash.tally_seq));
+  }
+
+  try {
+    const files = await Promise.all(promises);
+
+    for(let file of files) {
+      const fileData = file?.[0]?.file_data;
+      const file_fmt = file?.[0]?.file_fmt;
+      const digest = file?.[0]?.digest;
+
+      if(fileData) {
+        const base64 = Buffer.from(fileData).toString('base64')
+        const image = `data:${file_fmt};base64,${base64}`;
+        imagesByDigest[digest] = image;
+      }
+    }
+
+    await AsyncStorage.setItem(localStorage.TallyPictures, JSON.stringify(imagesByDigest));
+
+    setImagesByDigest(prev => {
+      return {
+        ...prev,
+        ...imagesByDigest
+      }
+    })
+  } catch(err) {
+    throw err;
+  }
 }
 
 const styles = StyleSheet.create({

--- a/client/chark/src/services/tally.js
+++ b/client/chark/src/services/tally.js
@@ -114,15 +114,19 @@ export const createTemplate = (wm, payload) => {
   return request(wm, 'new_template' + random(1000), 'insert', spec)
 }
 
-export const fetchTallyFile = (wm, hash) => {
+export const fetchTallyFile = (wm, digest, tally_seq) => {
   const spec = {
     name: 'file',
     view: 'mychips.tallies_v_me',
     data: {
+      key: {
+        tally_seq,
+      },
       options: {
-        hash,
+        digest,
+        format: 'json',
       }
-    },
+    }
   }
 
   return request(wm, 'fetch_tally_file' + random(1000), 'action', spec);
@@ -141,3 +145,4 @@ export const fetchTradingVariables = (wm, payload) => {
 
   return request(wm, 'fetch_trade' + random(1000), 'action', spec);
 }
+

--- a/lib/control/file.js
+++ b/lib/control/file.js
@@ -17,7 +17,8 @@ const tallySQL = `select
 function file(info, cb, resource) {
   let {data, view, origin, resPath, message, db, cache} = info
     , {keys, options} = data
-    , key = ((keys && keys.length >= 1) ? keys[0] : {}) ?? data.key
+    //, key = ((keys && keys.length >= 1) ? keys[0] : {}) ?? data.key
+    , key = keys?.[0] ?? data.key
     , error, content
 
   if (resource) {			//log.debug('  resource:', resource, 'cache:', cache.files)


### PR DESCRIPTION
- Fetched partner pictures from the backend using the action provided.
- From my research, it seems like we need to write native code to run, fetch and process the file buffer in the another thread(i.e in the background). So, for now I have fetched and processed the file in the same JavaScript thread. 
There seems to be a package called `next-frame` where the function’s execution will pause until the next render cycle starts. Might be good package to look into.
- I have also modified the key part in the `lib/control/file.js`