### PR TITLE
fixed swap icon on revise

### DIFF
--- a/client/chark/src/screens/Tally/TallyEditView.jsx
+++ b/client/chark/src/screens/Tally/TallyEditView.jsx
@@ -33,6 +33,8 @@ const TallyEditView = (props) => {
   const tallyContracts = props.tallyContracts ?? [];
   const canEdit = tally.state === 'draft' || tally.state === 'P.draft';
 
+  const showSwapIcon = props.showSwapIcon ?? false;
+
   const { messageText } = useMessageText();
   const talliesText = messageText?.tallies;
   const holdTermsText = messageText?.terms_lang?.hold_terms?.values;
@@ -70,6 +72,7 @@ const TallyEditView = (props) => {
   return (
     <View style={{ paddingHorizontal: 10 }}>
       <TallyReviewView 
+        canSwap={showSwapIcon}
         tallyType={tallyType}
         setTallyType={setTallyType}
         partTerms={partTerms}

--- a/client/chark/src/screens/Tally/TallyPreview/index.jsx
+++ b/client/chark/src/screens/Tally/TallyPreview/index.jsx
@@ -50,6 +50,8 @@ const TallyPreview = (props) => {
   const [tallyContracts, setTallyContracts] = useState([]);
   const [updateCert, setUpdateCert] = useState(false);
 
+  const [showSwapIcon, setShowSwapIcon] = useState(false);
+
   const {
     loading,
     refreshing,
@@ -245,6 +247,8 @@ const TallyPreview = (props) => {
   };
 
   const onRevise = () => {
+  return setShowSwapIcon(true)
+    
     reviseTally(wm, {
       tally_ent,
       tally_seq,
@@ -259,6 +263,8 @@ const TallyPreview = (props) => {
   };
 
   const onAccept = async () => {
+    setShowSwapIcon(false)
+    
     if (!tally?.json) {
       Alert.alert("Tally can not be signed");
       return;
@@ -301,6 +307,8 @@ const TallyPreview = (props) => {
   };
 
   const onRefuse = () => {
+    setShowSwapIcon(false)
+
     refuseTally(wm, {
       tally_ent,
       tally_seq,
@@ -321,6 +329,8 @@ const TallyPreview = (props) => {
   };
 
   const onVerify = async () => {
+    setShowSwapIcon(false)
+
     const creds = await retrieveKey(keyServices.publicKey);
     verifySignature(sig, JSON.stringify(tally.json), creds.password)
       .then((verified) => {
@@ -416,7 +426,7 @@ const TallyPreview = (props) => {
 
     if (canAccept) {
       return (
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', position: 'absolute', bottom: 5 }}>
+        <View style={styles.buttonWrapper}>
           <Button
             title="Revise"
             onPress={onRevise}
@@ -454,6 +464,7 @@ const TallyPreview = (props) => {
         >
           <TallyEditView
             tally={tally}
+            showSwapIcon={showSwapIcon}
             tallyType={tallyType}
             contract={contract}
             holdTerms={holdTerms}
@@ -607,7 +618,8 @@ const styles = StyleSheet.create({
     borderRadius: 18,
     height: 45,
     justifyContent: "center",
-  })
+  }),
+  buttonWrapper:{ flexDirection: 'row', justifyContent: 'space-between', position: 'absolute', bottom: 5, right:20, left:20 }
 });
 
 export default TallyPreview;

--- a/client/chark/src/screens/Tally/TallyPreview/index.jsx
+++ b/client/chark/src/screens/Tally/TallyPreview/index.jsx
@@ -247,7 +247,7 @@ const TallyPreview = (props) => {
   };
 
   const onRevise = () => {
-  return setShowSwapIcon(true)
+   setShowSwapIcon(true)
     
     reviseTally(wm, {
       tally_ent,

--- a/client/chark/src/screens/TallyReview/TallyReviewView.jsx
+++ b/client/chark/src/screens/TallyReview/TallyReviewView.jsx
@@ -108,11 +108,13 @@ const TallyReviewView = (props) => {
         </View>
       </View>
 
+{props.canSwap &&
       <View style={styles.absoluteView}>
         <TouchableOpacity onPress={onSwitchClick}>
           <SwapIcon />
         </TouchableOpacity>
       </View>
+}
     </View>
   );
 };


### PR DESCRIPTION
During a tally negotiation and the offer has been made we need to remove the arrow swap icon when the user is reviewing the tally. The swap icon will reappear when the tally is officially in a revising state