### PR TITLE
Add data dictionaries to tally preview screen and activity chit item

### DIFF
--- a/client/chark/src/components/MessageTextProvider.jsx
+++ b/client/chark/src/components/MessageTextProvider.jsx
@@ -11,7 +11,6 @@ const initialTexts = {
   exchange: null,
   userTallies: null,
   asset_v: null,
-  terms_lang: null,
   chits_v_me: null,
 }
 

--- a/client/chark/src/hooks/useLanguage.js
+++ b/client/chark/src/hooks/useLanguage.js
@@ -115,18 +115,20 @@ export const useUser = (wm) => {
   return messageText?.users ?? {};
 }
 
-export const useHoldTermsText = (wm) => {
+export const useTalliesMeText = (wm) => {
   const { messageText, setMessageText } = useMessageText();
 
   useEffect(() => {
-    wm.register('terms_lang' + Math.random(), 'mychips.tallies_v_me', (data, err) => {
-      if (data) {
-        addTextsToState('terms_lang', data.col, setMessageText)
-      }
-    })
+    if(!messageText?.tallies_v_me) {
+      wm.register('tallies_v_me' + Math.random(), 'mychips.tallies_v_me', (data, err) => {
+        if (data) {
+          addTextsToState('tallies_v_me', data, setMessageText)
+        }
+      })
+    }
   }, [])
 
-  return messageText?.terms_lang ?? {};
+  return messageText?.tallies_v_me ?? {};
 }
 
 export const useChitsMeText = (wm) => {
@@ -142,7 +144,7 @@ export const useChitsMeText = (wm) => {
     }
   }, [wm, setMessageText])
 
-  return messageText ?? {};
+  return messageText?.chits_v_me ?? {};
 }
 
 function addTextsToState(field, texts, setState) {

--- a/client/chark/src/screens/Activity/TallyItem.jsx
+++ b/client/chark/src/screens/Activity/TallyItem.jsx
@@ -132,9 +132,9 @@ const styles = StyleSheet.create({
   avatar: {
     marginRight: 8,
     alignSelf: 'center',
-    height: 45,
-    width: 45,
-    borderRadius: 45 / 2,
+    height: 60,
+    width: 60,
+    borderRadius: 60 / 2,
   },
   name: {
     ...font,

--- a/client/chark/src/screens/Invite/TallyEntryModal.jsx
+++ b/client/chark/src/screens/Invite/TallyEntryModal.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { View, Text, StyleSheet } from 'react-native';
 
-import { colors } from '../../config/constants';
 import Button from '../../components/Button';
 import Avatar from '../../components/Avatar';
 import HandshakeIcon from '../../../assets/svg/handshake.svg';
@@ -12,9 +11,15 @@ import CustomIcon from "../../components/CustomIcon";
 import OfferButton from '../Tally/OfferButton';
 import AcceptButton from '../Tally/AcceptButton';
 
+import { colors } from '../../config/constants';
+import useMessageText from '../../hooks/useMessageText';
+
 const TallyEntryModal = (props) => {
   const negotiationData = props.negotiationData;
   const { imagesByDigest } = useSelector(state => state.avatar);
+  const { messageText } = useMessageText();
+
+  const talliesMeText = messageText?.tallies_v_me?.col;
 
   return (
     <View style={{ margin: 20 }}>
@@ -37,16 +42,12 @@ const TallyEntryModal = (props) => {
         </Text>
 
         <Text style={{ color: colors.gray6 }}>
-          Wants to start a tally 
-        </Text>
-
-        <Text style={{ color: colors.gray6 }}>
-          with you
+          {talliesMeText?.tally_start?.title ?? 'wants_to_start_a_tally_with_you'}
         </Text>
 
         <View style={styles.partLimit}>
           <Text style={{ marginRight: 5, color: colors.gray6 }}>
-            Part limit ${negotiationData.data?.limit} 
+            part_limit ${negotiationData.data?.limit} 
           </Text>
           <GreenTickIcon />
         </View>
@@ -54,7 +55,7 @@ const TallyEntryModal = (props) => {
       
       {props.shouldShowReview &&
       <Button
-        title="Review"
+        title={talliesMeText?.review?.title ?? 'review'}
         onPress={() => props.onReview(negotiationData?.data?.tally_seq, negotiationData?.data?.tally_ent)}
         textColor={colors.blue}
         style={{ marginBottom: 5, borderRadius: 40, backgroundColor: colors.white }}

--- a/client/chark/src/screens/Invite/index.jsx
+++ b/client/chark/src/screens/Invite/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import {
   View,
   Text,
@@ -34,7 +34,7 @@ import { GenerateKeysDialog } from "../Tally/TallyPreview/GenerateKeysDialog";
 import TallyEntryModal from "./TallyEntryModal";
 
 import useMessageText from "../../hooks/useMessageText";
-import { useHoldTermsText } from "../../hooks/useLanguage";
+import { useTalliesMeText } from "../../hooks/useLanguage";
 import { fetchTemplates } from "../../redux/workingTalliesSlice";
 import { fetchImagesByDigest } from "../../redux/avatarSlice";
 import { request } from "../../services/request";
@@ -120,11 +120,15 @@ const TallyInvite = (props) => {
     data: undefined,
   });
 
-  useHoldTermsText(wm);
+  useTalliesMeText(wm);
   const { messageText } = useMessageText();
-  const draftLang = messageText?.terms_lang?.request?.values?.find(
-    (item) => item.value === "draft"
-  );
+  const talliesColText = messageText?.tallies_v_me?.col;
+
+  const draftLang = useMemo(() => {
+    return talliesColText?.request?.values?.find(
+      (item) => item.value === "draft"
+    );
+  }, [talliesColText?.request?.values])
 
   useEffect(() => {
     if (ws) {
@@ -296,7 +300,7 @@ const TallyInvite = (props) => {
               tally_ent: item.tally_ent,
             });
           }}
-          draftLang={draftLang?.title ?? "Draft"}
+          draftLang={draftLang?.title ?? "draft"}
         />
       </View>
     );

--- a/client/chark/src/screens/Tally/AcceptButton.jsx
+++ b/client/chark/src/screens/Tally/AcceptButton.jsx
@@ -59,7 +59,7 @@ const AcceptButton = (props) => {
 
   return (
     <Button
-      title="Accept"
+      title="accept"
       onPress={onAccept}
       disabled={accepting}
       textColor={colors.white}

--- a/client/chark/src/screens/Tally/CertificateInformation.jsx
+++ b/client/chark/src/screens/Tally/CertificateInformation.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -13,6 +13,15 @@ import HelpText from '../../components/HelpText';
 import { colors } from '../../config/constants';
 
 const CertificateInformation = (props) => {
+  const certText = props.certText;
+
+  const certValueText = useMemo(() => {
+    return certText?.values?.reduce((acc, curr) => {
+      acc[curr.value] = curr;
+      return acc;
+    }, {})
+  }, [certText?.values])
+
   return (
     <View style={styles.detailControl}>
       <HelpText
@@ -23,7 +32,8 @@ const CertificateInformation = (props) => {
       <View style={styles.certInfoWrapper}>
         <View style={styles.certInfo}>
           <HelpText
-            label={'Formal Name'}
+            label={certValueText?.part_name?.title ?? 'part_cert_name'}
+            helpText={certValueText?.name?.help?? ''}
             style={styles.certInfoLabel}
           />
 
@@ -34,7 +44,8 @@ const CertificateInformation = (props) => {
 
         <View style={styles.certInfo}>
           <HelpText
-            label={'Chip Address'}
+            label={certValueText?.chad?.title ?? 'part_chad'}
+            helpText={certValueText?.chad?.help}
             style={styles.certInfoLabel}
           />
 
@@ -46,7 +57,8 @@ const CertificateInformation = (props) => {
         {!!props.email && (
           <View style={styles.certInfo}>
             <HelpText
-              label={'Email'}
+              label={certValueText?.email?.title ?? 'partner_or_holder_email'}
+              helpText={certValueText?.email?.help}
               style={styles.certInfoLabel}
             />
 
@@ -58,7 +70,7 @@ const CertificateInformation = (props) => {
 
         <TouchableWithoutFeedback onPress={props.onViewDetails}>
           <Text style={styles.certOtherDetails}>
-            View other details
+            {certValueText?.other_details?.title ?? 'view_other_details'}
           </Text>
         </TouchableWithoutFeedback>
       </View>
@@ -109,6 +121,7 @@ CertificateInformation.prototype = {
   chipAddress: PropTypes.string.isRequired,
   email: PropTypes.string.isRequired,
   onViewDetails: PropTypes.func.isRequired,
+  certText: PropTypes.any.isRequired,
 }
 
 export default CertificateInformation;

--- a/client/chark/src/screens/Tally/EditOpenTally/index.jsx
+++ b/client/chark/src/screens/Tally/EditOpenTally/index.jsx
@@ -15,7 +15,7 @@ import {
 } from "../../../services/tally";
 import useSocket from "../../../hooks/useSocket";
 import { colors } from "../../../config/constants";
-import { useHoldTermsText, useTallyText } from "../../../hooks/useLanguage";
+import { useTalliesMeText, useTallyText } from "../../../hooks/useLanguage";
 
 import Button from "../../../components/Button";
 import CommonTallyView from "../CommonTallyView";
@@ -37,10 +37,12 @@ const EditOpenTally = (props) => {
 
   const [contractName, setContractName] = useState("");
 
-  useHoldTermsText(wm);
+  useTalliesMeText(wm);
   const { messageText } = useMessageText();
-  const holdTermsText = messageText?.terms_lang?.hold_terms?.values;
-  const partTermsText = messageText?.terms_lang?.part_terms?.values;
+  const talliesColText = messageText?.tallies_v_me?.col;
+  const holdTermsText = talliesColText?.hold_terms?.values;
+  const partTermsText = talliesColText?.part_terms?.values;
+
   const hasPartCert = !!tally?.part_cert;
   const hasHoldCert = !!tally?.hold_cert;
 

--- a/client/chark/src/screens/Tally/OfferButton.jsx
+++ b/client/chark/src/screens/Tally/OfferButton.jsx
@@ -58,7 +58,7 @@ const OfferButton = (props) => {
 
   return (
     <Button
-      title="Offer"
+      title="offer"
       disabled={offering}
       onPress={onOffer}
       textColor={colors.white}

--- a/client/chark/src/screens/Tally/PendingChits/ChitItem.jsx
+++ b/client/chark/src/screens/Tally/PendingChits/ChitItem.jsx
@@ -12,7 +12,6 @@ import Avatar from '../../../components/Avatar';
 import AcceptButton from './AcceptButton';
 import RejectButton from './RejectButton';
 import ChitTypeText from './ChitTypeText';
-import HelpText from '../../../components/HelpText';
 import { ChitIcon } from '../../../components/SvgAssets/SvgAssets';
 
 import { colors } from '../../../config/constants';

--- a/client/chark/src/screens/Tally/PendingChits/index.jsx
+++ b/client/chark/src/screens/Tally/PendingChits/index.jsx
@@ -14,14 +14,19 @@ import ChitItem from './ChitItem';
 import HelpText from '../../../components/HelpText'
 
 import { colors } from '../../../config/constants';
-import { getChits, resetChits } from '../../../redux/chitSlice';
+import { getChits } from '../../../redux/chitSlice';
 import useSocket from '../../../hooks/useSocket';
+import { useChitsMeText } from '../../../hooks/useLanguage';
 
 const PendingChits = (props) => {
   const dispatch = useDispatch();
   const { wm, chitTrigger } = useSocket();
   const { fetching, chits } = useSelector(state => state.chit)
   const { tally_uuid, partName, description, conversionRate } = props.route?.params ?? {};
+
+  // Register chits texts
+  const chitsMeText = useChitsMeText(wm);
+  const chitsMeMessageText = chitsMeText?.msg;
 
   const fetchChits = () => {
     dispatch(
@@ -73,7 +78,8 @@ const PendingChits = (props) => {
         keyExtractor={(_, index) => index}
         ListHeaderComponent={
           <HelpText
-            label={'Pending Chits'}
+            label={chitsMeMessageText?.pending?.title ?? ''}
+            helpText={chitsMeMessageText?.pending?.help}
             style={styles.listTitle}
           />
         }

--- a/client/chark/src/screens/Tally/TallyEdit.jsx
+++ b/client/chark/src/screens/Tally/TallyEdit.jsx
@@ -29,8 +29,8 @@ const TallyEditView = (props) => {
 
   const { messageText } = useMessageText();
   const talliesText = messageText?.tallies;
-  const holdTermsText = messageText?.terms_lang?.hold_terms?.values;
-  const partTermsText = messageText?.terms_lang?.part_terms?.values;
+  const holdTermsText = messageText?.tallies_v_me?.col?.hold_terms?.values;
+  const partTermsText = messageText?.tallies_v_me?.col?.part_terms?.values;
   const hasPartCert = !!tally?.part_cert;
   const hasHoldCert = !!tally?.hold_cert;
   const isCertUpdateable = tally?.status === 'draft';

--- a/client/chark/src/screens/Tally/TallyEditView.jsx
+++ b/client/chark/src/screens/Tally/TallyEditView.jsx
@@ -33,11 +33,11 @@ const TallyEditView = (props) => {
   const canEdit = tally.state === 'draft' || tally.state === 'P.draft';
 
   const { messageText } = useMessageText();
-  const talliesText = messageText?.tallies;
-  const holdTermsText = messageText?.terms_lang?.hold_terms?.values;
-  const partTermsText = messageText?.terms_lang?.part_terms?.values;
+
   const hasPartCert = !!tally?.part_cert;
   const hasHoldCert = !!tally?.hold_cert;
+
+  const talliesMeText = messageText?.tallies_v_me?.col;
 
   const partName= Object.values((tally.part_cert?.name ?? {})).join(' ')
   const partChipAddress = hasPartCert ? `${tally.part_cert?.chad?.cid ?? ''}-${tally.part_cert?.chad?.agent ?? ''}` : '';
@@ -89,8 +89,8 @@ const TallyEditView = (props) => {
       <View style={styles.detailControl}>
         <View style={styles.contractLabel}>
           <HelpText
-            label={talliesText?.contract?.title ?? ''}
-            helpText={talliesText?.contract?.help}
+            label={talliesMeText?.contract?.title ?? ''}
+            helpText={talliesMeText?.contract?.help}
           />
 
         <TouchableWithoutFeedback
@@ -126,31 +126,33 @@ const TallyEditView = (props) => {
         )}
 
         {hasPartCert && (
-            <CertificateInformation
-              title={'Partner Certificate Information'}
-              name={partName}
-              chipAddress={partChipAddress}
-              email={partEmail}
-              onViewDetails={onViewCertificate({ title: 'Partner Certificate', cert: tally?.part_cert ?? {} })}
-            />
+          <CertificateInformation
+            title={talliesMeText?.part_cert?.title ?? ''}
+            name={partName}
+            chipAddress={partChipAddress}
+            email={partEmail}
+            onViewDetails={onViewCertificate({ title: 'Partner Certificate', cert: tally?.part_cert ?? {} })}
+            certText={talliesMeText?.part_cert ?? {}}
+          />
         )}
 
         {!!tally?.hold_cert && (
-            <CertificateInformation
-              title={'My Certificate Information'}
-              name={holdName}
-              chipAddress={holdChipAddress}
-              email={holdEmail}
-              onViewDetails={onViewCertificate({ title: 'My Certificate', cert: tally?.hold_cert ?? {} } )}
-            />
+          <CertificateInformation
+            title={talliesMeText?.hold_cert?.title ?? ''}
+            name={holdName}
+            chipAddress={holdChipAddress}
+            email={holdEmail}
+            onViewDetails={onViewCertificate({ title: 'My Certificate', cert: tally?.hold_cert ?? {} } )}
+            certText={talliesMeText?.hold_cert ?? {}}
+          />
         )}
 
       </View>
 
       <View style={styles.detailControl}>
         <HelpText
-          label={talliesText?.comment?.title ?? ''}
-          helpText={talliesText?.comment?.help}
+          label={talliesMeText?.comment?.title ?? ''}
+          helpText={talliesMeText?.comment?.help}
         />
 
         {canEdit ? (
@@ -171,8 +173,8 @@ const TallyEditView = (props) => {
 
       <View style={styles.detailControl}>
         <HelpText
-          label={talliesText?.tally_uuid?.title ?? ''}
-          helpText={talliesText?.tally_uuid?.help}
+          label={talliesMeText?.tally_uuid?.title ?? ''}
+          helpText={talliesMeText?.tally_uuid?.help}
         />
 
         <Text style={styles.inputValue}>
@@ -182,8 +184,8 @@ const TallyEditView = (props) => {
 
       <View style={styles.detailControl}>
         <HelpText
-          label={talliesText?.tally_date?.title ?? ''}
-          helpText={talliesText?.tally_date?.help}
+          label={talliesMeText?.tally_date?.title ?? ''}
+          helpText={talliesMeText?.tally_date?.help}
         />
         <Text style={styles.inputValue}>
           {moment(tally.tally_date).format('MM/DD/YYYY,hh:mm')} 

--- a/client/chark/src/screens/Tally/TallyPreview/index.jsx
+++ b/client/chark/src/screens/Tally/TallyPreview/index.jsx
@@ -12,10 +12,10 @@ import {
   Text,
 } from "react-native";
 
-import { colors, keyServices } from "../../../config/constants";
+import { colors } from "../../../config/constants";
 import useSocket from "../../../hooks/useSocket";
 import useInvite from "../../../hooks/useInvite";
-import { useHoldTermsText, useTallyText } from "../../../hooks/useLanguage";
+import { useTalliesMeText } from "../../../hooks/useLanguage";
 import useTallyUpdate from "../../../hooks/useTallyUpdate";
 import { fetchContracts, updateHoldCert } from "../../../services/tally";
 
@@ -24,7 +24,7 @@ import Button from "../../../components/Button";
 import Spinner from "../../../components/Spinner";
 import TallyEditView from "../TallyEditView";
 import { Toast } from "react-native-toast-message/lib/src/Toast";
-import { refuseTally, reviseTally } from "../../../services/tally";
+import { reviseTally } from "../../../services/tally";
 import { GenerateKeysDialog } from "./GenerateKeysDialog";
 import { UpdateHoldCert } from "./UpdateHoldCert";
 import CenteredModal from "../../../components/CenteredModal";
@@ -116,8 +116,8 @@ const TallyPreview = (props) => {
   };
 
   // Fetch tally text
-  useTallyText(wm);
-  useHoldTermsText(wm);
+  const talliesMeText = useTalliesMeText(wm)
+  const talliesColText = talliesMeText?.col ?? {};
 
   const onShare = () => {
     const hold_limit = tally?.hold_terms?.limit;
@@ -254,26 +254,6 @@ const TallyPreview = (props) => {
     props.navigation.navigate("TallyContract", { tally_seq });
   };
 
-  const onRefuse = () => {
-    refuseTally(wm, {
-      tally_ent,
-      tally_seq,
-    })
-      .then(() => {
-        Toast.show({
-          type: "success",
-          text1: "Tally refused.",
-        });
-        props.navigation.goBack();
-      })
-      .catch((err) => {
-        Toast.show({
-          type: "error",
-          text1: err.message,
-        });
-      });
-  };
-
   const onCancel = () => {
     props.navigation.navigate("Invite");
   };
@@ -378,7 +358,7 @@ const TallyPreview = (props) => {
       return (
         <View style={styles.buttonWrapper}>
           <Button
-            title="Revise"
+            title={talliesColText?.revise?.title ?? 'revise_text'}
             onPress={onRevise}
             textColor={colors.white}
             style={[styles.fullActionButton(colors.yellow), { width: '48%' }]}

--- a/client/chark/src/screens/TallyReview/TallyReviewView.jsx
+++ b/client/chark/src/screens/TallyReview/TallyReviewView.jsx
@@ -11,6 +11,7 @@ import { useSelector } from "react-redux";
 import Avatar from "../../components/Avatar";
 import { colors } from "../../config/constants";
 import HelpText from "../../components/HelpText";
+import useMessageText from '../../hooks/useMessageText';
 
 import {
   SwapIcon,
@@ -30,6 +31,9 @@ const TallyReviewView = (props) => {
   const holdLimit = props.holdTerms?.limit;
   const partLimit = props.partTerms?.limit;
   const canEdit = props.canEdit ?? true;
+
+  const { messageText } = useMessageText();
+  const talliesMeText = messageText?.tallies_v_me?.col;
 
   const onSwitchClick = () => {
     props.setTallyType((prev) => {
@@ -82,7 +86,7 @@ const TallyReviewView = (props) => {
         <View style={styles.rowWrapper}>
           <View style={styles.leftIcon}>
             <HelpText
-              label="Risk"
+              label={talliesMeText?.risk?.title ?? 'risk_title'}
               style={[styles.leftText, styles.leftTopText]}
             />
             <DownArrowIcon />
@@ -114,7 +118,7 @@ const TallyReviewView = (props) => {
 
           <View style={styles.rightIcon}>
             <HelpText
-              label="Credit"
+              label={talliesMeText?.credit?.title ?? 'credit_title'}
               style={[styles.rightText, styles.rightTopText]}
             />
             <LeftArrowIcon />
@@ -163,7 +167,7 @@ const TallyReviewView = (props) => {
           <View style={styles.leftIcon}>
             <RightArrowIcon />
             <HelpText
-              label="Credit"
+              label={talliesMeText?.credit?.title ?? 'credit_title'}
               style={[styles.leftText, styles.leftBottomText]}
             />
           </View>
@@ -195,7 +199,7 @@ const TallyReviewView = (props) => {
           <View style={styles.rightIcon}>
             <UpArrowIcon />
             <HelpText
-              label="Risk"
+              label={talliesMeText?.risk?.title ?? 'risk_title'}
               style={[styles.rightText, styles.rightBottomText]}
             />
           </View>


### PR DESCRIPTION
- Add data dictionaries to tally preview screen and activity's chit item
- Fetched the translations for liability and asset on pending chits.